### PR TITLE
Owen/generator/simple inscribe verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SRC_DIR := src
 
 DOCKER_USERNAME := bitseed
 DOCKER_IMAGE_NAME := $(DOCKER_USERNAME)/$(PROJECT_NAME)
-DOCKER_IMAGE_TAG := 0.1.5-debug1
+DOCKER_IMAGE_TAG := 0.1.5-debug6
 
 # Target for building the project
 build:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SRC_DIR := src
 
 DOCKER_USERNAME := bitseed
 DOCKER_IMAGE_NAME := $(DOCKER_USERNAME)/$(PROJECT_NAME)
-DOCKER_IMAGE_TAG := 0.1.5
+DOCKER_IMAGE_TAG := 0.1.5-debug1
 
 # Target for building the project
 build:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SRC_DIR := src
 
 DOCKER_USERNAME := bitseed
 DOCKER_IMAGE_NAME := $(DOCKER_USERNAME)/$(PROJECT_NAME)
-DOCKER_IMAGE_TAG := 0.1.5-debug6
+DOCKER_IMAGE_TAG := 0.1.6
 
 # Target for building the project
 build:

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -2,6 +2,8 @@ use crate::inscribe::InscribeOptions;
 use crate::inscribe::Inscriber;
 use crate::wallet::Wallet;
 use crate::SubcommandResult;
+use crate::operation::deploy_args_cbor_encode;
+
 use clap::Parser;
 use ord::InscriptionId;
 
@@ -32,6 +34,8 @@ pub struct DeployCommand {
 
 impl DeployCommand {
     pub fn run(self, wallet: Wallet) -> SubcommandResult {
+        let deploy_args = deploy_args_cbor_encode(self.deploy_args);
+
         //TODO check the tick name is valid
         let tick = self.tick.to_uppercase();
         let output = Inscriber::new(wallet, self.inscribe_options)?
@@ -40,7 +44,7 @@ impl DeployCommand {
                 self.amount,
                 self.generator,
                 self.repeat,
-                self.deploy_args,
+                deploy_args,
             )?
             .inscribe()?;
         Ok(Box::new(output))

--- a/src/commands/generator.rs
+++ b/src/commands/generator.rs
@@ -5,6 +5,8 @@ use crate::SubcommandResult;
 use clap::Parser;
 use std::path::PathBuf;
 
+use tracing::debug;
+
 /// Inscribe a new generator bytecode to Bitcoin
 #[derive(Debug, Parser)]
 pub struct GeneratorCommand {
@@ -18,6 +20,8 @@ pub struct GeneratorCommand {
 
 impl GeneratorCommand {
     pub fn run(self, wallet: Wallet) -> SubcommandResult {
+        debug!("GeneratorCommand 1");
+
         let output = Inscriber::new(wallet, self.inscribe_options)?
             .with_generator(self.name, self.generator)?
             .inscribe()?;

--- a/src/commands/generator.rs
+++ b/src/commands/generator.rs
@@ -5,8 +5,6 @@ use crate::SubcommandResult;
 use clap::Parser;
 use std::path::PathBuf;
 
-use tracing::debug;
-
 /// Inscribe a new generator bytecode to Bitcoin
 #[derive(Debug, Parser)]
 pub struct GeneratorCommand {
@@ -20,8 +18,6 @@ pub struct GeneratorCommand {
 
 impl GeneratorCommand {
     pub fn run(self, wallet: Wallet) -> SubcommandResult {
-        debug!("GeneratorCommand 1");
-
         let output = Inscriber::new(wallet, self.inscribe_options)?
             .with_generator(self.name, self.generator)?
             .inscribe()?;

--- a/src/generator/mock/random_amount_generator.rs
+++ b/src/generator/mock/random_amount_generator.rs
@@ -7,14 +7,14 @@ pub struct RandomAmountGenerator;
 impl Generator for RandomAmountGenerator {
     fn inscribe_generate(
         &self,
-        deploy_args: &Vec<String>,
+        _deploy_args: &Vec<u8>,
         seed: &InscribeSeed,
         _recipient: &Address,
         _user_input: Option<String>,
     ) -> crate::generator::InscribeGenerateOutput {
         let hash = seed.seed();
-        let min = deploy_args[0].parse::<u64>().unwrap();
-        let max = deploy_args[1].parse::<u64>().unwrap();
+        let min = 1;
+        let max = 100;
         let amount = (U256::from_little_endian(hash.as_bytes()) % (max - min) + min).as_u64();
         crate::generator::InscribeGenerateOutput {
             amount,
@@ -25,7 +25,7 @@ impl Generator for RandomAmountGenerator {
 
     fn inscribe_verify(
         &self,
-        deploy_args: &Vec<String>,
+        deploy_args: &Vec<u8>,
         seed: &InscribeSeed,
         recipient: &Address,
         user_input: Option<String>,

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod hash;
 pub(crate) mod mock;
 pub mod wasm;
 
+use tracing::{info};
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct InscribeGenerateOutput {
     pub amount: u64,
@@ -36,8 +38,16 @@ impl InscribeSeed {
 
     pub fn seed(&self) -> H256 {
         let mut buffer = self.block_hash.as_byte_array().to_vec();
-        buffer.extend_from_slice(self.utxo.txid.as_byte_array());
-        buffer.extend_from_slice(&self.utxo.vout.to_le_bytes());
+        info!("block_hash_hex:{:?}", hex::encode(buffer.clone()));
+
+        let txid_bytes = self.utxo.txid.as_byte_array();
+        info!("txid_bytes:{:?}", hex::encode(txid_bytes.clone()));
+        buffer.extend_from_slice(txid_bytes);
+
+        let vout_bytes = self.utxo.vout.to_le_bytes();
+        info!("vout_bytes:{:?}", hex::encode(vout_bytes.clone()));
+        buffer.extend_from_slice(&vout_bytes);
+
         hash::sha3_256_of(buffer.as_slice())
     }
 }
@@ -187,7 +197,6 @@ impl GeneratorLoader {
             content.content_type
         );
         let wasm_bytecode = &content.body;
-        //TODO load generator from Inscription
         Ok(Box::new(WASMGenerator::new(wasm_bytecode.clone())))
     }
 }

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -80,7 +80,7 @@ pub const CONTENT_TYPE: &'static str = "application/wasm";
 pub trait Generator {
     fn inscribe_generate(
         &self,
-        deploy_args: &Vec<String>,
+        deploy_args: &Vec<u8>,
         seed: &InscribeSeed,
         recipient: &Address,
         user_input: Option<String>,
@@ -88,7 +88,7 @@ pub trait Generator {
 
     fn inscribe_verify(
         &self,
-        deploy_args: &Vec<String>,
+        deploy_args: &Vec<u8>,
         seed: &InscribeSeed,
         recipient: &Address,
         user_input: Option<String>,
@@ -101,7 +101,7 @@ pub trait Generator {
 
     fn indexer_generate(
         &self,
-        _deploy_args: Vec<String>,
+        _deploy_args: Vec<u8>,
         _seed: &IndexerSeed,
         _recipient: Address,
     ) -> IndexerGenerateOutput {
@@ -129,7 +129,7 @@ impl StaticGenerator {
 impl Generator for StaticGenerator {
     fn inscribe_generate(
         &self,
-        _deploy_args: &Vec<String>,
+        _deploy_args: &Vec<u8>,
         _seed: &InscribeSeed,
         _recipient: &Address,
         _user_input: Option<String>,
@@ -139,7 +139,7 @@ impl Generator for StaticGenerator {
 
     fn inscribe_verify(
         &self,
-        _deploy_args: &Vec<String>,
+        _deploy_args: &Vec<u8>,
         _seed: &InscribeSeed,
         _recipient: &Address,
         _user_input: Option<String>,
@@ -154,7 +154,7 @@ impl Generator for StaticGenerator {
 
     fn indexer_generate(
         &self,
-        _deploy_args: Vec<String>,
+        _deploy_args: Vec<u8>,
         _seed: &IndexerSeed,
         _recipient: Address,
     ) -> IndexerGenerateOutput {

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -11,8 +11,6 @@ pub(crate) mod hash;
 pub(crate) mod mock;
 pub mod wasm;
 
-use tracing::{info};
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct InscribeGenerateOutput {
     pub amount: u64,
@@ -38,14 +36,11 @@ impl InscribeSeed {
 
     pub fn seed(&self) -> H256 {
         let mut buffer = self.block_hash.as_byte_array().to_vec();
-        info!("block_hash_hex:{:?}", hex::encode(buffer.clone()));
 
         let txid_bytes = self.utxo.txid.as_byte_array();
-        info!("txid_bytes:{:?}", hex::encode(txid_bytes.clone()));
         buffer.extend_from_slice(txid_bytes);
 
         let vout_bytes = self.utxo.vout.to_le_bytes();
-        info!("vout_bytes:{:?}", hex::encode(vout_bytes.clone()));
         buffer.extend_from_slice(&vout_bytes);
 
         hash::sha3_256_of(buffer.as_slice())

--- a/src/generator/wasm/wasm_generator.rs
+++ b/src/generator/wasm/wasm_generator.rs
@@ -236,6 +236,8 @@ impl WASMGenerator {
 
         let mut buffer_map = serde_json::Map::new();
 
+        info!("generate_buffer_final->deploy_args:{:?}", &deploy_args);
+
         buffer_map.insert(
             "attrs".to_string(),
             serde_json::Value::Array(attrs_buffer_vec),
@@ -261,6 +263,9 @@ impl WASMGenerator {
         let mut buffer_final = Vec::new();
         buffer_final.append(&mut (top_buffer.len() as u32).to_be_bytes().to_vec());
         buffer_final.append(&mut top_buffer);
+
+        let hex_buffer = hex::encode(buffer_final.clone());
+        info!("generate_buffer_final->buffer_final:{:?}", hex_buffer);
 
         put_data_on_stack(memory, stack_alloc_func, store, buffer_final.as_slice())
     }
@@ -319,6 +324,11 @@ impl Generator for WASMGenerator {
                 }
             }
         }
+
+        info!("inscribe_generate output: {:?}", &inscribe_generate_output);
+
+        let inscribe_output_bytes = inscribe_output_to_cbor(inscribe_generate_output.clone());
+        info!("inscribe_output_bytes: {:?}", hex::encode(inscribe_output_bytes));
 
         inscribe_generate_output
     }

--- a/src/generator/wasm/wasm_generator.rs
+++ b/src/generator/wasm/wasm_generator.rs
@@ -211,26 +211,15 @@ impl WASMGenerator {
 
     fn generate_buffer_final_ptr(
         &self,
-        deploy_args: &Vec<String>,
+        deploy_args: &Vec<u8>,
         seed: &InscribeSeed,
         user_input: Option<String>,
         memory: &mut Arc<Mutex<Memory>>,
         stack_alloc_func: &Function,
         store: &mut Store,
     ) -> i32 {
-        let mut mint_args_json: Vec<JSONValue> = vec![];
-        for arg in deploy_args.iter() {
-            let arg_json: JSONValue =
-                serde_json::from_str(arg.as_str()).expect("serde_json unmarshal failed");
-            mint_args_json.push(arg_json);
-        }
-
-        let mint_args_array = JSONValue::Array(mint_args_json);
-        let mut cbor_buffer = Vec::new();
-        ciborium::into_writer(&mint_args_array, &mut cbor_buffer).expect("ciborium marshal failed");
-
         let mut attrs_buffer_vec = Vec::new();
-        for byte in cbor_buffer.iter() {
+        for byte in deploy_args.iter() {
             attrs_buffer_vec.push(serde_json::Value::Number(Number::from(byte.clone())));
         }
 
@@ -274,7 +263,7 @@ impl WASMGenerator {
 impl Generator for WASMGenerator {
     fn inscribe_generate(
         &self,
-        deploy_args: &Vec<String>,
+        deploy_args: &Vec<u8>,
         seed: &InscribeSeed,
         _recipient: &Address,
         user_input: Option<String>,
@@ -335,7 +324,7 @@ impl Generator for WASMGenerator {
 
     fn inscribe_verify(
         &self,
-        deploy_args: &Vec<String>,
+        deploy_args: &Vec<u8>,
         seed: &InscribeSeed,
         _recipient: &Address,
         user_input: Option<String>,
@@ -456,6 +445,7 @@ mod tests {
     use std::fs::read;
     use std::str::FromStr;
     use env_logger;
+    use crate::operation::deploy_args_cbor_encode;
      
     #[test]
     fn test_inscribe_generate_normal() {
@@ -466,6 +456,7 @@ mod tests {
         let generator = WASMGenerator::new(bytecode);
 
         let deploy_args = vec![r#"{"height":{"type":"range","data":{"min":1,"max":1000}}}"#.to_string()];
+        let deploy_args = deploy_args_cbor_encode(deploy_args);
 
         // Block hash
         let block_hash_hex = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
@@ -517,6 +508,7 @@ mod tests {
         let generator = WASMGenerator::new(bytecode);
 
         let deploy_args = vec![r#"{"height":{"type":"range","data":{"min":1,"max":1000}}}"#.to_string()];
+        let deploy_args = deploy_args_cbor_encode(deploy_args);
 
         // Block hash
         let block_hash_hex = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
@@ -557,6 +549,7 @@ mod tests {
         let generator = WASMGenerator::new(bytecode);
 
         let deploy_args = vec![r#"{"height":{"type":"range","data":{"min":1,"max":1000}}}"#.to_string()];
+        let deploy_args = deploy_args_cbor_encode(deploy_args);
 
         // Block hash
         let block_hash_hex = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";

--- a/src/generator/wasm/wasm_generator.rs
+++ b/src/generator/wasm/wasm_generator.rs
@@ -10,7 +10,7 @@ use wasmer::*;
 use tracing::{error, debug, info};
 
 use crate::sft;
-use crate::generator::{Generator, InscribeGenerateOutput, Content, InscribeSeed};
+use crate::generator::{Generator, InscribeGenerateOutput, InscribeSeed};
 
 #[allow(dead_code)]
 #[derive(Clone)]

--- a/src/inscribe.rs
+++ b/src/inscribe.rs
@@ -184,7 +184,7 @@ impl Inscriber {
         amount: u64,
         generator: InscriptionId,
         repeat: u64,
-        deploy_args: Vec<String>,
+        deploy_args: Vec<u8>,
     ) -> Result<Self> {
         //TODO check the generator exists.
         let deploy_record = DeployRecord {

--- a/src/inscribe.rs
+++ b/src/inscribe.rs
@@ -31,6 +31,8 @@ use {
     std::{collections::BTreeMap, path::Path},
 };
 
+use tracing::debug;
+
 const TARGET_POSTAGE: Amount = Amount::from_sat(10_000);
 
 #[derive(Debug, Clone, Parser)]
@@ -161,12 +163,16 @@ impl Inscriber {
     where
         P: AsRef<Path>,
     {
+        debug!("with_generator 1");
+
         let bytecode = std::fs::read(generator_program)?;
         let content = Content::new(generator::CONTENT_TYPE.to_string(), bytecode);
         let attributes = Value::Map(vec![(
             Value::Text("name".to_string()),
             Value::Text(generator_name.clone().into()),
         )]);
+
+        debug!("with_generator 2");
         let mint_record = MintRecord {
             sft: SFT {
                 tick: GENERATOR_TICK.to_string(),
@@ -175,6 +181,8 @@ impl Inscriber {
                 content: Some(content),
             },
         };
+
+        debug!("with_generator 3");
         Ok(self.with_operation(Operation::Mint(mint_record)))
     }
 

--- a/src/inscribe.rs
+++ b/src/inscribe.rs
@@ -31,8 +31,6 @@ use {
     std::{collections::BTreeMap, path::Path},
 };
 
-use tracing::debug;
-
 const TARGET_POSTAGE: Amount = Amount::from_sat(10_000);
 
 #[derive(Debug, Clone, Parser)]
@@ -163,8 +161,6 @@ impl Inscriber {
     where
         P: AsRef<Path>,
     {
-        debug!("with_generator 1");
-
         let bytecode = std::fs::read(generator_program)?;
         let content = Content::new(generator::CONTENT_TYPE.to_string(), bytecode);
         let attributes = Value::Map(vec![(
@@ -172,7 +168,6 @@ impl Inscriber {
             Value::Text(generator_name.clone().into()),
         )]);
 
-        debug!("with_generator 2");
         let mint_record = MintRecord {
             sft: SFT {
                 tick: GENERATOR_TICK.to_string(),
@@ -182,7 +177,6 @@ impl Inscriber {
             },
         };
 
-        debug!("with_generator 3");
         Ok(self.with_operation(Operation::Mint(mint_record)))
     }
 

--- a/tests/features/generator.feature
+++ b/tests/features/generator.feature
@@ -46,7 +46,7 @@ Feature: Bitseed CLI integration tests
     # mine a block
     Then cmd ord: "wallet receive"
     Then cmd bitcoin-cli: "generatetoaddress 1 {{$.wallet[-1].address}}"
-    Then sleep: "10"
+    Then sleep: "30"
 
     # merge 
     Then cmd bitseed: "merge --fee-rate 1 --sft-inscription-ids {{$.split[-1].inscriptions[0].Id}} --sft-inscription-ids {{$.split[-1].inscriptions[1].Id}} --sft-inscription-ids {{$.split[-1].inscriptions[2].Id}}"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -353,6 +353,8 @@ async fn bitseed_run_cmd(w: &mut World, input_tpl: String) {
                 } else {
                     "Thread panicked with unknown message".to_string()
                 };
+
+                debug!("bitseed_run_cmd error:{:?}", &panic_info);
                 tx.send(Err(anyhow::anyhow!(err_msg))).unwrap();
             }
         }


### PR DESCRIPTION
Simplify the bitseed of deploy_args processing logic
- [x] When deploying the generator, directly encode deploy_args with cbor
- [x] When executing mint, directly use the cbor-encoded deploy_args
